### PR TITLE
Update the README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,34 +1,48 @@
 # Hello Triangle with WebGL and Rust
 
-This is a minimal example that demonstrates how to render a triangle with WebAssembly, WebGL, Rust, and zero dependencies.
+This is a minimal example that demonstrates how to render a triangle with WebAssembly, WebGL, Rust, and zero dependencies.  There's a tutorial that goes along with this example at [rust-tutorials.github.io](https://rust-tutorials.github.io/triangle-from-scratch/web_stuff/web_gl_with_bare_wasm.html)
 
 To build the project perform the following steps:
 
 1. Install Rust.
 2. Install the `wasm32-unknown-unknown` target: `rustup target add wasm32-unknown-unknown`
 3. Build the directory: `cargo build --target wasm32-unknown-unknown`
-4. Run a local server to host the project directory. `devserver` is the easiest to setup:
-    * First run `cargo install devserver`
-    * Then simply run `devserver`. 
-5. Navigate to `localhost:8080` and view the triangle!
+4. Run a local server to host the project directory.  If you are running VSCode, you can just launch `index.html` in the preview pane.
 
-The `.wasm` file produced is around 1.5mb. Which is kinda big!
+## Installing a local web server
 
+If you aren't using VSCode you will need some other web server installed to view the example.
+
+### Using Python as a web server
+
+If you have python installed, you can use this one-liner from the root of your local copy of this repo:
+
+`python3 -m http.server 8080`
+
+or
+
+`python -m SimpleHTTPServer 8080`
+
+Navigate to `localhost:8080` in your web browser and view the triangle!
+
+### Using devserver
+
+You can try using a minimal webserver for development `devserver`:
+
+* First run `cargo install devserver`
+* Then simply run `devserver`.
+* Navigate to `localhost:8080` in your web browser and view the triangle!
+
+Note that if your system uses opensslv3, you may encounter errors from the SSL library about unspported RC2-40-CBC algorithm due to the self-signed certificate used by this binary.
 
 ## How to create a smaller .wasm file
 
-If you'd like to make a smaller .wasm file you need to instruct the compiler to remove all the extra debugging information it adds. Unfortunately you can't do this with stable Rust right now, but nightly Rust has a flag we can use.
+The `.wasm` file produced under `target/wasm32-unknown-unknown/debug` is around 1.4mb. Which is kinda big!
 
-To install nightly Rust with WebAssembly support follow the following steps:
+Now you can run a build a *release* build with most of the compiler information stripped out:
 
-1. Install nightly Rust: `rustup install nightly`
-2. Make it your default with `rustup default nightly`
-3. Install WebAssembly support for nightly `rustup target add wasm32-unknown-unknown`
-
-Now you can run a build a *release* build with all compiler information stripped out:
-
-`cargo rustc --target wasm32-unknown-unknown --release -- -Z strip=symbols`
+`cargo build --target wasm32-unknown-unknown --release`
 
 You must change this line in `index.html` to `fetch('target/wasm32-unknown-unknown/release/hello_triangle_wasm_rust.wasm')` to make sure it points to the release folder.
 
-This new stripped .wasm file is 16kb instead of 1.6mb. 1/100th the size!
+This new stripped .wasm file is 22kb instead of 1.4mb. Less than 2% the original size!


### PR DESCRIPTION
The Rust development environment has changed a little since this example was originaly written. This README file update should help a new Rust developer get up and running in 2025.